### PR TITLE
Add USB Interface Association Descriptor (IAD)

### DIFF
--- a/keyboard.c
+++ b/keyboard.c
@@ -172,8 +172,8 @@ keyboard_del_key(uint8_t key)
 void
 keyboard_add_modifier(uint8_t modifier)
 {
-    keyboard_state.mods |= MODIFIER_BIT(modifier);
-    nkro_state.mods |= MODIFIER_BIT(modifier);
+    keyboard_state.mods |= modifier;
+    nkro_state.mods |= modifier;
 
     if (nkro_active) {
         nkro_dirty = true;
@@ -185,8 +185,8 @@ keyboard_add_modifier(uint8_t modifier)
 void
 keyboard_del_modifier(uint8_t modifier)
 {
-    keyboard_state.mods &= ~MODIFIER_BIT(modifier);
-    nkro_state.mods &= ~MODIFIER_BIT(modifier);
+    keyboard_state.mods &= ~modifier;
+    nkro_state.mods &= ~modifier;
 
     if (nkro_active) {
         nkro_dirty = true;

--- a/keymap.h
+++ b/keymap.h
@@ -111,7 +111,10 @@ enum {
 #define _C(Key)                   {.type = KMT_CONSUMER, .extra = { .code = CONSUMER_##Key }}
 #define _K(Key)                   {.type = KMT_KEY, .key = { .mod = 0, .code = KEY_##Key }}
 #define _KC(Code)                 {.type = KMT_KEY, .key = { .mod = 0, .code = 0x##Code }}
-#define _KM(Mod, Key)             {.type = KMT_KEY, .key = { .mod = KEY_##Mod, .code = KEY_##Key }}
+/* Example CTRL-D: _KM(LCTRL, D) */
+#define _KM(ModKey, Key)          {.type = KMT_KEY, .key = { .mod = MOD_##ModKey, .code = KEY_##Key }}
+/* Example CTRL-ALT-DEL: _KMB(MOD_LCTRL|MOD_LALT, DELETE) */
+#define _KMB(ModBits, Key)        {.type = KMT_KEY, .key = { .mod = ModBits, .code = KEY_##Key }}
 #define _L(Layer)                 {.type = KMT_LAYER, .layer = { .number = Layer }}
 #define _M(X,Y)                   {.type = KMT_MOUSE, .mouse = {.button = 0, .x = X, .y = Y }}
 #define _MA(Number)               {.type = KMT_MACRO, .macro = { .number = Number }}

--- a/usb.c
+++ b/usb.c
@@ -507,14 +507,14 @@ static const struct usb_endpoint_descriptor data_endpoint[] = {{
     .bEndpointAddress = USB_ENDPOINT_ADDR_OUT(EP_SERIALDATAOUT),
     .bmAttributes = USB_ENDPOINT_ATTR_BULK,
     .wMaxPacketSize = EP_SIZE_SERIALDATAOUT,
-    .bInterval = 0x0a,
+    .bInterval = 1,
     }, {
     .bLength = USB_DT_ENDPOINT_SIZE,
     .bDescriptorType = USB_DT_ENDPOINT,
     .bEndpointAddress = USB_ENDPOINT_ADDR_IN(EP_SERIALDATAIN),
     .bmAttributes = USB_ENDPOINT_ATTR_BULK,
     .wMaxPacketSize = EP_SIZE_SERIALDATAIN,
-    .bInterval = 0x0a,
+    .bInterval = 1,
     }};
 
 static const struct {
@@ -578,10 +578,21 @@ static const struct usb_interface_descriptor cdc_data_iface[] = {{
     .bInterfaceClass = USB_CLASS_DATA,
     .bInterfaceSubClass = 0,
     .bInterfaceProtocol = 0,
-    .iInterface = STRI_COMMAND,
+    .iInterface = 0,
 
     .endpoint = data_endpoint,
     }};
+
+static const struct usb_iface_assoc_descriptor cdc_assoc = {
+    .bLength = USB_DT_INTERFACE_ASSOCIATION_SIZE,
+    .bDescriptorType = USB_DT_INTERFACE_ASSOCIATION,
+    .bFirstInterface = IF_SERIALCOMM,
+    .bInterfaceCount = 2,
+    .bFunctionClass = USB_CLASS_CDC,
+    .bFunctionSubClass = USB_CDC_SUBCLASS_ACM,
+    .bFunctionProtocol = USB_CDC_PROTOCOL_NONE,
+    .iFunction = STRI_COMMAND,
+    };
 
 const struct usb_interface ifaces[] = {{
     .num_altsetting = 1,
@@ -596,7 +607,8 @@ const struct usb_interface ifaces[] = {{
     .num_altsetting = 1,
     .altsetting = &nkro_iface,
     }, {
-        .num_altsetting = 1,
+    .num_altsetting = 1,
+    .iface_assoc = &cdc_assoc,
     .altsetting = cdc_comm_iface,
     }, {
     .num_altsetting = 1,
@@ -606,10 +618,10 @@ const struct usb_interface ifaces[] = {{
 const struct usb_device_descriptor dev_descriptor = {
     .bLength = USB_DT_DEVICE_SIZE,
     .bDescriptorType = USB_DT_DEVICE,
-    .bcdUSB = 0x0110,
-    .bDeviceClass = 0,                     /* Each interface will specify its own class code */
-    .bDeviceSubClass = 0,
-    .bDeviceProtocol = 0,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = 0xEF,      /* USB 2.0 ECN Interface Association Descriptor (IAD) */
+    .bDeviceSubClass = 0x02,   /* https://www.usb.org/sites/default/files/iadclasscode_r10.pdf */
+    .bDeviceProtocol = 0x01,
     .bMaxPacketSize0 = 64,
     .idVendor = 0xDEAD,
     .idProduct = 0xBEEF,

--- a/usb_keycode.h
+++ b/usb_keycode.h
@@ -28,6 +28,18 @@
 #ifndef _KEYCODE_H
 #define _KEYCODE_H
 
+/**
+ * Modifier key bits
+ */
+#define MOD_LCTRL   0x01
+#define MOD_LSHIFT  0x02
+#define MOD_LALT    0x04
+#define MOD_LGUI    0x08
+#define MOD_RCTRL   0x10
+#define MOD_RSHIFT  0x20
+#define MOD_RALT    0x40
+#define MOD_RGUI    0x80
+
 /*
  * Keycode definitions as present in the usb hid usage tables, and as available
  * as valid key events for linux.
@@ -265,8 +277,6 @@ enum hid_keyboard_keypad_usage {
 
     /* 0xe8 - 0xff = Reserved */
 };
-
-#define MODIFIER_BIT(mod) (1<<(mod & 0x07))
 
 enum hid_system_usage {
 


### PR DESCRIPTION
Required for Windows and probably Mac.